### PR TITLE
将 kotlin-stdlib 添加到 src\main\assembly\plugin.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <elasticsearch.version>7.16.2</elasticsearch.version>
+        <elasticsearch.version>7.16.3</elasticsearch.version>
 
         <jackson.version>2.10.4</jackson.version>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -47,12 +47,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.4.10</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
             <version>1.4.10</version>
         </dependency>
 

--- a/src/main/assembly/plugin.xml
+++ b/src/main/assembly/plugin.xml
@@ -43,6 +43,7 @@
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
                 <include>com.squareup.okhttp3:okhttp</include>
+                <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                 <include>com.hankcs:hanlp</include>
                 <include>com.vdurmont:emoji-java</include>
             </includes>


### PR DESCRIPTION
- pom.xml 中去掉 kotlin-stdlib-common，因为它是 kotlin-stdlib 的子依赖
- 将 kotlin-stdlib 添加到 src\main\assembly\plugin.xml，这样 kotlin-stdlib.jar 才会进入最终的 zip 文件
- 将 elasticsearch 版本号由 7.16.2 更新到 7.16.3