### PR TITLE
在 dingWebHookUrl 为空时，不发送钉钉网络请求。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <elasticsearch.version>7.17.0</elasticsearch.version>
+        <elasticsearch.version>7.17.1</elasticsearch.version>
 
         <jackson.version>2.10.4</jackson.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/com/itenlee/search/analysis/help/DingRotService.java
+++ b/src/main/java/com/itenlee/search/analysis/help/DingRotService.java
@@ -23,6 +23,12 @@ public class DingRotService {
             "}";
 
     public static void sendDingTalkMessage(String content, String webHook) {
+        if (webHook.trim().length() < 1) {
+            String msg = String.format("msg: %s. dingWebHookUrl is empty!", content);
+            logger.info(msg);
+            return;
+        }
+
         content = content.replace("\\", "\\\\").replace("\"", "\\\"");
         String json = String.format(MESSAGE_TEXT, content);
         try {


### PR DESCRIPTION
- 升级 elasticsearch.version 为 7.17.1
- 在 dingWebHookUrl 为空时，不发送钉钉网络请求。