### PR TITLE
remoteFreqDict 不可能为 null

### DIFF
--- a/src/main/java/com/itenlee/search/analysis/core/Dictionary.java
+++ b/src/main/java/com/itenlee/search/analysis/core/Dictionary.java
@@ -64,8 +64,8 @@ public class Dictionary {
                         instance = new Dictionary(cfg);
 
                         instance.loadDict();
-
-                        if (cfg.getRemoteFreqDict() != null) {
+                        
+                        if ((cfg.getRemoteFreqDict() != null) && (cfg.getRemoteFreqDict().trim().length() > 0)) {
                             if (cfg.getSyncDicPeriodTime() == null || cfg.getSyncDicPeriodTime() < 30) {
                                 logger.warn("syncDicPeriodTime illegal: must >= 30");
                             } else {


### PR DESCRIPTION
cfg.remoteFreqDict 初始化时就被赋值为字符串，不可能为 null。
原代码导致配置文件中远程词典链接为空时，也会尝试加载远程词典